### PR TITLE
chore: Remove modal swipe support

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -51,8 +51,6 @@ const ChatWootWidget = ({
       style={styles.modal}
       coverScreen
       isVisible={isModalVisible}
-      onSwipeComplete={() => isModalVisible}
-      swipeDirection="left"
       onBackdropPress={closeModal}
       onBackButtonPress={closeModal}>
       <View style={styles.mainView}>


### PR DESCRIPTION
Fixes #15 
Support for swipe seems to be interfering with the touches/taps within the widget.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## How Has This Been Tested?
Simulated the issue by manually creating a separate component that simulates this widget i.e. create a Webview with a link to the widget wrapped within a react-native-modal Modal. With the swipeDirection prop of the Modal commented, taps within the widget worked as expected. 


## Checklist:
No new code added. Optional params removed.
