### PR TITLE
Fix Chatwoot Modal Crash Caused by Deprecated BackHandler

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "react-native-modal": "^13.0.1"
+    "react-native-modal": "^14.0.0-rc.1"
   },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.23.1",


### PR DESCRIPTION
Fixes #52 

Clicking the `X` button on the Chatwoot modal triggers the deprecated error mentioned in the issue. 

React Native 0.77.0 deprecated `BackHandler.removeEventListener`, which is still used by the version of `react-native-modal` bundled with Chatwoot. With Expo SDK 53 requiring React Native 0.79, this results in the reported error.

The latest version of `react-native-modal` resolves this issue. I have verified the fix by using npm overrides to force Chatwoot to use the updated version, and the modal now works as expected.