### PR TITLE
fix: re-inject user data when widget signals it is ready

### DIFF
--- a/src/WebView.js
+++ b/src/WebView.js
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import { StyleSheet, Linking, View, ActivityIndicator, Text } from 'react-native';
 import { WebView } from 'react-native-webview';
 import PropTypes from 'prop-types';
@@ -29,6 +29,7 @@ const WebViewComponent = ({
   customAttributes = {},
   closeModal,
 }) => {
+  const webViewRef = useRef(null);
   const [currentUrl, setCurrentUrl] = React.useState(null);
   const [loading, setLoading] = useState(true);
   let widgetUrl = `${baseUrl}/widget?website_token=${websiteToken}&locale=${locale}`;
@@ -83,6 +84,7 @@ const WebViewComponent = ({
   return (
     <View style={styles.container}>
       <WebView
+        ref={webViewRef}
         source={{
           uri: widgetUrl,
         }}
@@ -97,6 +99,13 @@ const WebViewComponent = ({
                 config: { authToken },
               } = parsedMessage;
               storeHelper.storeCookie(authToken);
+              // Re-inject user data now that the widget is fully initialized.
+              // The injectedJavaScript prop fires when the WebView page loads,
+              // but the Chatwoot widget may not have set up its message listeners
+              // yet at that point. The 'loaded' event signals the widget is ready.
+              if (webViewRef.current) {
+                webViewRef.current.injectJavaScript(injectedJavaScript + '; true;');
+              }
             }
             if (type === 'close-widget') {
               closeModal();


### PR DESCRIPTION
## Problem

User data (name, email, identifier), locale, custom attributes, and color scheme are intermittently not applied to the Chatwoot widget. This is a race condition reported in #31.

### Root cause

`injectedJavaScript` fires as soon as the WebView page finishes loading, but the Chatwoot widget's internal JavaScript may not have initialized its `message` event listeners at that point. The `window.postMessage()` calls containing user data are silently dropped.

## Solution

Add a WebView ref and re-inject the user/locale/customAttributes/colorScheme scripts when the widget fires its `loaded` event — the exact moment it signals readiness to receive messages.

- The existing `injectedJavaScript` prop is kept as an optimistic first attempt (works when timing is favorable)
- The `loaded` event handler acts as a reliable, event-driven fallback

This is a minimal, non-breaking change — only `src/WebView.js` is touched.

## Changes

1. Import `useRef` from React
2. Create a `webViewRef` and attach it to the `<WebView>` component
3. In the `onMessage` handler, when `eventType === 'loaded'`, call `webViewRef.current.injectJavaScript()` with the same scripts

## Related issues

Fixes #31