### PR TITLE
fix: BackHandler crash on RN 0.79+ — replace react-native-modal with core Modal

### DIFF
--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -8,13 +8,12 @@
       "name": "example",
       "version": "1.0.0",
       "dependencies": {
-        "@chatwoot/react-native-widget": "^0.0.19",
+        "@chatwoot/react-native-widget": "^0.0.20",
         "@react-native-async-storage/async-storage": "1.23.1",
         "expo": "~51.0.28",
         "expo-status-bar": "~1.12.1",
         "react": "18.2.0",
         "react-native": "0.74.5",
-        "react-native-modal": "^13.0.1",
         "react-native-webview": "13.8.6"
       },
       "devDependencies": {
@@ -2090,9 +2089,10 @@
       }
     },
     "node_modules/@chatwoot/react-native-widget": {
-      "version": "0.0.19",
-      "resolved": "https://registry.npmjs.org/@chatwoot/react-native-widget/-/react-native-widget-0.0.19.tgz",
-      "integrity": "sha512-NQZ9FxYJXUrhXMyJcpNksRdAzYIYIBuUO/OlJqQtV71SJU0UCpzTg5WEFrQZb1qxFgSTV4eqaXJSeL/QkEjnGQ==",
+      "version": "0.0.20",
+      "resolved": "https://registry.npmjs.org/@chatwoot/react-native-widget/-/react-native-widget-0.0.20.tgz",
+      "integrity": "sha512-cCb+ZjoyAb1WSzL/rPkco9SnDNepWMRVtwAylA9nEDKaw0vX/a3GAKpEmmnguM8eA2RI7bmmIojVuRPz4OhGcg==",
+      "license": "MIT",
       "dependencies": {
         "react-native-modal": "^13.0.1"
       },

--- a/Example/package.json
+++ b/Example/package.json
@@ -15,7 +15,6 @@
     "expo-status-bar": "~1.12.1",
     "react": "18.2.0",
     "react-native": "0.74.5",
-    "react-native-modal": "^13.0.1",
     "react-native-webview": "13.8.6"
   },
   "devDependencies": {

--- a/Example/src/App.js
+++ b/Example/src/App.js
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { SafeAreaView, Appearance } from 'react-native';
-import Modal from 'react-native-modal';
+import { SafeAreaView, Appearance, Modal } from 'react-native';
 import PropTypes from 'prop-types';
 import { storeHelper, findColors } from './utils';
 import WebView from './WebView';
 import styles from './style';
-import { COLOR_WHITE } from './constants';
 
 const propTypes = {
   isModalVisible: PropTypes.bool.isRequired,
@@ -51,12 +49,9 @@ const ChatWootWidget = ({
   });
   return (
     <Modal
-      backdropColor={COLOR_WHITE}
-      coverScreen
-      isVisible={isModalVisible}
-      onBackButtonPress={closeModal}
-      onBackdropPress={closeModal}
-      style={styles.modal}>
+      animationType="slide"
+      visible={isModalVisible}
+      onRequestClose={closeModal}>
       <SafeAreaView style={[styles.headerView, { backgroundColor: headerBackgroundColor }]} />
       <SafeAreaView style={[styles.mainView, { backgroundColor: mainBackgroundColor }]}>
         <WebView

--- a/Example/src/style.js
+++ b/Example/src/style.js
@@ -1,11 +1,6 @@
 const { StyleSheet } = require('react-native');
 
 const styles = StyleSheet.create({
-  modal: {
-    flex: 1,
-    margin: 0,
-    paddingVertical: 0,
-  },
   mainView: {
     flex: 1,
   },

--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
     "lint": "eslint .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
-    "react-native-modal": "^13.0.1"
-  },
   "peerDependencies": {
     "@react-native-async-storage/async-storage": ">=1.23.1",
     "react": "*",

--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import { SafeAreaView, Appearance } from 'react-native';
-import Modal from 'react-native-modal';
+import { SafeAreaView, Appearance, Modal } from 'react-native';
 import PropTypes from 'prop-types';
 import { storeHelper, findColors } from './utils';
 import WebView from './WebView';
 import styles from './style';
-import { COLOR_WHITE } from './constants';
 
 const propTypes = {
   isModalVisible: PropTypes.bool.isRequired,
@@ -51,12 +49,9 @@ const ChatWootWidget = ({
   });
   return (
     <Modal
-      backdropColor={COLOR_WHITE}
-      coverScreen
-      isVisible={isModalVisible}
-      onBackButtonPress={closeModal}
-      onBackdropPress={closeModal}
-      style={styles.modal}>
+      animationType="slide"
+      visible={isModalVisible}
+      onRequestClose={closeModal}>
       <SafeAreaView style={[styles.headerView, { backgroundColor: headerBackgroundColor }]} />
       <SafeAreaView style={[styles.mainView, { backgroundColor: mainBackgroundColor }]}>
         <WebView

--- a/src/style.js
+++ b/src/style.js
@@ -1,11 +1,6 @@
 const { StyleSheet } = require('react-native');
 
 const styles = StyleSheet.create({
-  modal: {
-    flex: 1,
-    margin: 0,
-    paddingVertical: 0,
-  },
   mainView: {
     flex: 1,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2099,7 +2099,7 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -2125,21 +2125,6 @@ react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
-
-react-native-animatable@1.3.3:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/react-native-animatable/-/react-native-animatable-1.3.3.tgz#a13a4af8258e3bb14d0a9d839917e9bb9274ec8a"
-  integrity sha512-2ckIxZQAsvWn25Ho+DK3d1mXIgj7tITkrS4pYDvx96WyOttSvzzFeQnM2od0+FUMzILbdHDsDEqZvnz1DYNQ1w==
-  dependencies:
-    prop-types "^15.7.2"
-
-react-native-modal@^13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/react-native-modal/-/react-native-modal-13.0.1.tgz#691f1e646abb96fa82c1788bf18a16d585da37cd"
-  integrity sha512-UB+mjmUtf+miaG/sDhOikRfBOv0gJdBU2ZE1HtFWp6UixW9jCk/bhGdHUgmZljbPpp0RaO/6YiMmQSSK3kkMaw==
-  dependencies:
-    prop-types "^15.6.2"
-    react-native-animatable "1.3.3"
 
 react-refresh@^0.4.0:
   version "0.4.3"


### PR DESCRIPTION
Fixes #52 (same crash as the accidentally-closed #53).

## Problem

`react-native-modal@13.0.1` still calls `BackHandler.removeEventListener` in `componentWillUnmount`. React Native deprecated it in 0.77 and has since removed it, so **closing the widget crashes any app on RN 0.79+ / Expo SDK 53+**:

```
TypeError: _reactNative.BackHandler.removeEventListener is not a function (it is undefined)
```

Today every consumer has to carry a patch-package fix for this (we run this widget in four production apps and each one needs the patch).

## Why not bump react-native-modal

- `13.0.2` contains the fix but is **deprecated on npm as "mistakenly released"**, which is exactly why the current `^13.0.1` range keeps resolving to the broken `13.0.1`.
- `14.x` only exists as release candidates (`14.0.0-rc.1`), and the library is in low-maintenance mode.

## Fix

The widget only renders a full-screen modal and uses four props, all of which React Native's built-in `Modal` covers — so this drops the dependency entirely:

| react-native-modal | core Modal |
|---|---|
| `isVisible` | `visible` |
| `onBackButtonPress` | `onRequestClose` (Android back) |
| default `slideInUp`/`slideOutDown` | `animationType="slide"` |
| `coverScreen`, `backdropColor`, `margin: 0` style | unnecessary — core Modal is full-screen by default |

`onBackdropPress` is dropped: with `coverScreen` + full-screen styling there is no visible backdrop to press, so it was dead code. Consumers also lose the `react-native-modal` + `react-native-animatable` subtree from their installs, and the patch-package workaround becomes unnecessary.

`Example/` carries a vendored copy of the same component, so it gets the same change; its `package-lock.json` also picks up the pre-existing `^0.0.20` manifest sync.

## Testing

- Render tests in a real RN 0.81 jest environment: widget mounts with the webview, `onRequestClose` fires `closeModal`, and unmounting no longer crashes (the old crash fired in `componentWillUnmount`).
- `eslint` clean on the changed files.
- We run this widget (with the equivalent behavior) in four production React Native apps (RN 0.81–0.85, Expo SDK 54–56).

🤖 Generated with [Claude Code](https://claude.com/claude-code)